### PR TITLE
readme: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Deleting tag busybox:latest ...Tag deleted successfully!
 Combine both to delete all tags:
 
 ```
-$ for i in `registry-rmtag`; do registry-rmtag $i; done
+$ for i in `registry-ls`; do registry-rmtag $i; done
 Deleting tag busybox:one ...Tag deleted successfully!
 Deleting tag busybox:two ...Tag deleted successfully!
 Deleting tag busybox:three ...Tag deleted successfully!


### PR DESCRIPTION
not sure what the intended code was supposed to be, but `docker-rm` seems definitely wrong.

also, you refer in readme to this PR: https://github.com/mayflower/docker-ls/pull/8
which was not merged because author did not act on feedback. however last comment says:
>  v0.3.0 supports configuring the registry via DOCKER_LS_REGISTRY
